### PR TITLE
build: temporary fix for wayland/nvidia linux bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/bin
 node_modules
 frontend/dist
+.flatpak-builder

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build-linux
+build-linux:
+	flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo && \
+	flatpak-builder --force-clean --user --install-deps-from=flathub --repo=build/bin/repo build/bin/build-dir build/linux/app.runik.runik.yml && \
+	flatpak build-bundle build/bin/repo build/bin/runik_linux.flatpak app.runik.runik

--- a/build/linux/app.runik.runik.yml
+++ b/build/linux/app.runik.runik.yml
@@ -1,14 +1,14 @@
 app-id: app.runik.runik
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
-  - org.freedesktop.Sdk.Extension.node20
+  - org.freedesktop.Sdk.Extension.node22
 build-options:
   build-args:
     - --share=network
-  append-path: /usr/lib/sdk/golang/bin:/usr/lib/sdk/node20/bin
+  append-path: /usr/lib/sdk/golang/bin:/usr/lib/sdk/node22/bin
   env:
     GOBIN: /app/bin
     GOROOT: /usr/lib/sdk/golang
@@ -24,6 +24,10 @@ finish-args:
   - --filesystem=host
   - --share=network
   - --talk-name=org.kde.StatusNotifierWatcher
+  # FIXME: Handle Wayland/Nvidia bug in webkit (remove this when the bug is 
+  # properly addressed).
+  # https://github.com/tauri-apps/tauri/issues/10702#issuecomment-2327642878
+  - --env=WEBKIT_DISABLE_DMABUF_RENDERER=1
 modules:
   - name: wails
     buildsystem: simple


### PR DESCRIPTION
There is bug rendering webkit applications on wayland with nvidia. This is an upstream bug, the env variable added to the build instructions for linux is a temporary fix.

https://github.com/tauri-apps/tauri/issues/10702#issuecomment-2327642878