### PR TITLE
fix: linux desktop file target for flatpak build

### DIFF
--- a/build/linux/app.runik.runik.metainfo.xml
+++ b/build/linux/app.runik.runik.metainfo.xml
@@ -27,7 +27,7 @@
     </p>
   </description>
   
-  <launchable type="desktop-id">runik.desktop</launchable>
+  <launchable type="desktop-id">app.runik.runik.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://github.com/Runik-3/core/blob/main/assets/runik_screenshot.png</image>

--- a/build/linux/app.runik.runik.yml
+++ b/build/linux/app.runik.runik.yml
@@ -41,7 +41,7 @@ modules:
       - install -Dm755 build/bin/runik /app/bin/runik
       # install app meta, desktop entry, icon
       - install -Dm755 build/linux/app.runik.runik.metainfo.xml /app/share/metainfo/app.runik.runik.metainfo.xml
-      - install -Dm755 build/linux/runik.desktop /app/share/applications/runik.desktop
+      - install -Dm755 build/linux/runik.desktop /app/share/applications/app.runik.runik.desktop
       - install -Dm755 build/appicon.png /app/share/icons/hicolor/256x256/apps/app.runik.runik.png
     sources:
       - type: dir 


### PR DESCRIPTION
The file name was incorrect according to the flatpak documentation, causing the desktop entry to not properly get created.